### PR TITLE
extra dependency in DNS record

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -171,6 +171,8 @@ module "task" {
 
 // Add ALB record on DNS
 resource "aws_route53_record" "main" {
+  depends_on = ["aws_ecs_service.main"]
+
   zone_id = "${var.zone_id}"
   name    = "${var.name}"
   type    = "A"


### PR DESCRIPTION
In certain circumstances this could prevent go live meanwhile the service is still being created
 